### PR TITLE
[Bugfix] Environment variable ending with =

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -22,7 +22,7 @@ var GitCommit string
 
 const (
 	// Version defines main version number
-	Version = "0.3.1"
+	Version = "0.3.2"
 
 	// VersionPrerelease is pre-release marker for the version
 	// such as "dev" (in development), "beta", "rc1", etc.

--- a/job/jobs_fetch_test.go
+++ b/job/jobs_fetch_test.go
@@ -121,14 +121,14 @@ func TestGenerateJobs(t *testing.T) {
 		}
 	}()
 
-    select {
-    case <-notifyStdoutSent:
-        log.Trace("notifyStdoutSent")
-    case <-time.After(1 * time.Second):
-        t.Errorf("timed out")
-    }
+	select {
+	case <-notifyStdoutSent:
+		log.Trace("notifyStdoutSent")
+	case <-time.After(1 * time.Second):
+		t.Errorf("timed out")
+	}
 	for job := range jobs {
-        time.Sleep(50*time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 		if job.Status != model.JOB_STATUS_PENDING {
 			t.Errorf("Expected %s, got %s", model.JOB_STATUS_PENDING, job.Status)
 		}
@@ -142,7 +142,7 @@ func TestGenerateJobs(t *testing.T) {
 			cancel()
 		}
 		foundEnv := false
-        time.Sleep(100*time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 		for _, v := range job.CmdENV {
 			if "EnvVar=1" == v {
 				foundEnv = true

--- a/model/utils.go
+++ b/model/utils.go
@@ -29,7 +29,8 @@ func MergeEnvVars(CmdENVs []string) (uniqueMergedENV []string) {
 	mergedENV = append(mergedENV, DefaultPath())
 	unique := make(map[string]bool, len(mergedENV))
 	for indx := range mergedENV {
-		if len(strings.Split(mergedENV[indx], "=")) != 2 {
+
+		if len(strings.Split(mergedENV[indx], "=")) < 2 {
 			continue
 		}
 		k := strings.Split(mergedENV[indx], "=")[0]
@@ -37,9 +38,6 @@ func MergeEnvVars(CmdENVs []string) (uniqueMergedENV []string) {
 			uniqueMergedENV = append(uniqueMergedENV, mergedENV[indx])
 			unique[k] = true
 		}
-		// if strings.HasPrefix(j.cmd.Env[indx],"PATH="){
-		//     j.cmd.Env[indx]
-		// }
 	}
 	return
 }

--- a/model/utils_test.go
+++ b/model/utils_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+    b64 "encoding/base64"
 	"go.uber.org/goleak"
 	"os"
 	"runtime"
@@ -48,6 +49,36 @@ func TestMergeEnvVars(t *testing.T) {
 		t.Errorf("want %s, got %v", want, got)
 	}
 	want = "PATH="
+	if !strings.Contains(joined, want) {
+		t.Errorf("want %s, got %v", want, got)
+	}
+}
+
+func TestMergeEnvVarsBase64(t *testing.T) {
+	defer func() {
+        os.Unsetenv("SUPRAWORKER_T")
+	}()
+	os.Unsetenv("SUPRAWORKER_T")
+    data := "abc123!?$*&()'-=@~"
+    sEnc := fmt.Sprintf("%s==",b64.StdEncoding.EncodeToString([]byte(data)))
+	want := fmt.Sprintf("SUPRAWORKER_T=%s", sEnc)
+
+    joined := strings.Join(MergeEnvVars([]string{}), ";")
+    if strings.Contains(joined, want) {
+        t.Errorf("want '%s' be absent, got %v", want, joined)
+    }
+    //
+	got := MergeEnvVars([]string{want})
+	if len(got) < 1 {
+		t.Errorf("want len > 0 got %s", got)
+	}
+	joined = strings.Join(got, ";")
+	if !strings.Contains(joined, want) {
+		t.Errorf("want %s, got %v", want, got)
+	}
+    os.Setenv("SUPRAWORKER_T", fmt.Sprintf("%s",sEnc))
+    got = MergeEnvVars([]string{})
+    joined = strings.Join(got, ";")
 	if !strings.Contains(joined, want) {
 		t.Errorf("want %s, got %v", want, got)
 	}

--- a/model/utils_test.go
+++ b/model/utils_test.go
@@ -1,8 +1,8 @@
 package model
 
 import (
+	b64 "encoding/base64"
 	"fmt"
-    b64 "encoding/base64"
 	"go.uber.org/goleak"
 	"os"
 	"runtime"
@@ -56,18 +56,18 @@ func TestMergeEnvVars(t *testing.T) {
 
 func TestMergeEnvVarsBase64(t *testing.T) {
 	defer func() {
-        os.Unsetenv("SUPRAWORKER_T")
+		os.Unsetenv("SUPRAWORKER_T")
 	}()
 	os.Unsetenv("SUPRAWORKER_T")
-    data := "abc123!?$*&()'-=@~"
-    sEnc := fmt.Sprintf("%s==",b64.StdEncoding.EncodeToString([]byte(data)))
+	data := "abc123!?$*&()'-=@~"
+	sEnc := fmt.Sprintf("%s==", b64.StdEncoding.EncodeToString([]byte(data)))
 	want := fmt.Sprintf("SUPRAWORKER_T=%s", sEnc)
 
-    joined := strings.Join(MergeEnvVars([]string{}), ";")
-    if strings.Contains(joined, want) {
-        t.Errorf("want '%s' be absent, got %v", want, joined)
-    }
-    //
+	joined := strings.Join(MergeEnvVars([]string{}), ";")
+	if strings.Contains(joined, want) {
+		t.Errorf("want '%s' be absent, got %v", want, joined)
+	}
+	//
 	got := MergeEnvVars([]string{want})
 	if len(got) < 1 {
 		t.Errorf("want len > 0 got %s", got)
@@ -76,9 +76,9 @@ func TestMergeEnvVarsBase64(t *testing.T) {
 	if !strings.Contains(joined, want) {
 		t.Errorf("want %s, got %v", want, got)
 	}
-    os.Setenv("SUPRAWORKER_T", fmt.Sprintf("%s",sEnc))
-    got = MergeEnvVars([]string{})
-    joined = strings.Join(got, ";")
+	os.Setenv("SUPRAWORKER_T", fmt.Sprintf("%s", sEnc))
+	got = MergeEnvVars([]string{})
+	joined = strings.Join(got, ";")
 	if !strings.Contains(joined, want) {
 		t.Errorf("want %s, got %v", want, got)
 	}

--- a/model/utils_test.go
+++ b/model/utils_test.go
@@ -76,7 +76,7 @@ func TestMergeEnvVarsBase64(t *testing.T) {
 	if !strings.Contains(joined, want) {
 		t.Errorf("want %s, got %v", want, got)
 	}
-	os.Setenv("SUPRAWORKER_T", fmt.Sprintf("%s", sEnc))
+	os.Setenv("SUPRAWORKER_T", sEnc)
 	got = MergeEnvVars([]string{})
 	joined = strings.Join(got, ";")
 	if !strings.Contains(joined, want) {


### PR DESCRIPTION
We are encoding the vars with the following code
```python
python3 -c 'import json, base64;print(base64.b64encode(json.dumps({ "param":"value1"} ).encode("utf8")).decode("utf8"))'

```
the variable is similar to `eyJwYXJhbSI6ICJ2YWx1ZTEifQ==`